### PR TITLE
fix(stylint):add stylint support to match changes in remote .hound.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ tslint:
 ruby:
   enabled: true
   config_file: style/config/.rubocop.yml
-scss:
+stylelint:
   enabled: true
-  config_file: style/config/.scss-lint.yml
+  config_file: style/config/.stylelintrc.json
 ```
 
 And running...
@@ -53,7 +53,7 @@ You will get in your `$HOME` path the following files:
 ```
 .eslintrc.json
 .rubocop.yml
-.scss-lint.yml
+.stylelintrc.json
 ```
 
 Also, you can pass a linter's name to update rules for specific languages.

--- a/lib/hound.rb
+++ b/lib/hound.rb
@@ -13,7 +13,7 @@ require "hound/config/base"
 require "hound/config/ruby"
 require "hound/config/eslint"
 require "hound/config/tslint"
-require "hound/config/scss"
+require "hound/config/stylelint"
 
 module Hound
 end

--- a/lib/hound/config/stylelint.rb
+++ b/lib/hound/config/stylelint.rb
@@ -1,8 +1,8 @@
 module Hound
   module Config
-    class Scss < Base
+    class Stylelint < Base
       def initialize
-        @linters_file_name = ".scss-lint.yml"
+        @linters_file_name = ".stylelintrc.json"
       end
     end
   end

--- a/lib/hound/config_collection.rb
+++ b/lib/hound/config_collection.rb
@@ -2,7 +2,7 @@ module Hound
   module ConfigCollection
     extend self
 
-    LINTER_NAMES = %w{ruby eslint tslint scss}
+    LINTER_NAMES = %w{ruby eslint tslint stylelint}
 
     def config_instances(linter_names = [])
       linter_names = LINTER_NAMES if linter_names.empty?

--- a/spec/hound_config_spec.rb
+++ b/spec/hound_config_spec.rb
@@ -11,7 +11,7 @@ describe HoundConfig do
 
     it "returns the content of the remote config file" do
       expect(HoundConfig.content).to eq(
-        "scss" => { "enabled" => false },
+        "stylelint" => { "enabled" => true },
         "ruby" => { "config_file" => ".ruby-style.yml" },
         "javascript" => { "ignore_file" => ".javascript_ignore" }
       )

--- a/spec/support/assets/config/.hound.enabled.yml
+++ b/spec/support/assets/config/.hound.enabled.yml
@@ -1,5 +1,5 @@
-scss:
-  enabled: false
+stylelint:
+  enabled: true
 
 ruby:
   enabled: true

--- a/spec/support/assets/config/.hound.remote.yml
+++ b/spec/support/assets/config/.hound.remote.yml
@@ -1,5 +1,5 @@
-scss:
-  enabled: false
+stylelint:
+  enabled: true
 
 ruby:
   config_file: .ruby-style.yml

--- a/spec/support/assets/rules/.scss-lint.yml
+++ b/spec/support/assets/rules/.scss-lint.yml
@@ -1,7 +1,0 @@
-linters:
-  Rule1:
-    enabled: true
-  Rule2:
-    enabled: true
-  Rule3:
-    enabled: true

--- a/spec/support/assets/rules/.stylelintrc.json
+++ b/spec/support/assets/rules/.stylelintrc.json
@@ -1,0 +1,7 @@
+{
+  "rules": {
+    "rule1": true,
+    "ruel2": false,
+    "ruel3": false
+  }
+}


### PR DESCRIPTION
Cuando se hizo el cambio de scss-lint por stylelint en https://github.com/platanus/la-guia, no se actualizó la gema de Hound que va a buscar el archivo .hound.yml y las configuraciones para cada linter. Por ende, la gema seguía buscando a scss-lint. Ahora se considera este cambio en la gema.