### PR TITLE
fix(gemspec): change rest-client dependency version

### DIFF
--- a/hound-cli.gemspec
+++ b/hound-cli.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "colorize", "~> 0.7", ">= 0.7.7"
-  spec.add_dependency "rest-client", "~> 1.8", ">= 1.8.0"
+  spec.add_dependency "rest-client", "~> 2.0"
   spec.add_dependency "commander", "~> 4.4", ">= 4.4.0"
 
   spec.add_development_dependency "bundler", "~> 1.12"


### PR DESCRIPTION
Se cambia la versión de la dependencia `rest-client` a 2.0 dado que soluciona el siguiente error que se obtenía al ejecutar `hound rules update` con ruby versión 2.5.1:
`'fetch': key not found: :ciphers (KeyError)`

Issues al respecto:
1. https://github.com/rest-client/rest-client/issues/612
2. https://github.com/cloudinary/cloudinary_gem/issues/320